### PR TITLE
fix: Correct path for diagram CSVs and enhance build output summary

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -5,6 +5,9 @@ on:
   # Deploy the Pages site when a new release is published
   release:
     types: [published]
+  # Deploy automatically when code is pushed to master so site and diagrams stay up-to-date
+  push:
+    branches: [master]
   # Allow manual runs
   workflow_dispatch:
 
@@ -44,7 +47,15 @@ jobs:
       - name: Copy diagram CSVs into build output
         run: |
           mkdir -p docs/dist/ts-diagrams
-          cp -r ts-diagrams/* docs/dist/ts-diagrams/
+          # The diagram CSVs are located under docs/ts-diagrams, not the repository root
+          cp -r docs/ts-diagrams/* docs/dist/ts-diagrams/
+
+      - name: Show build output summary (for debugging)
+        run: |
+          echo "-- dist/index.html --"
+          ls -la docs/dist | sed -n '1,200p'
+          echo "-- dist/ts-diagrams --"
+          ls -la docs/dist/ts-diagrams | sed -n '1,200p'
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
This pull request updates the deployment workflow for GitHub Pages to ensure the site and diagram assets are always current. The most important changes include enabling automatic deployments on every push to the `master` branch, correcting the source location for diagram files, and adding a build output summary for easier debugging.

**Deployment automation:**

* Added a trigger to deploy the Pages site automatically whenever code is pushed to the `master` branch, in addition to releases and manual runs.

**Asset management and debugging:**

* Fixed the path used to copy diagram CSVs into the build output, ensuring files are sourced from `docs/ts-diagrams` instead of the repository root.
* Added a step to show a summary of the build output for debugging, listing contents of `docs/dist` and `docs/dist/ts-diagrams`.

## Summary by Sourcery

Enhance the GitHub Pages deployment workflow to auto-deploy on master pushes, correct CSV asset paths, and add a build output summary for easier debugging

Enhancements:
- Fix path for copying diagram CSVs from docs/ts-diagrams into build output
- Add a build output summary step to list contents of docs/dist and docs/dist/ts-diagrams for debugging

Deployment:
- Trigger automatic deployment of the GitHub Pages site on pushes to master in addition to releases and manual runs