### PR TITLE
Update copyright year in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Anselm Hahn
+Copyright (c) 2019-2026 Anselm Hahn
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request contains a minor update to the copyright information in the `LICENSE` file, extending the copyright years to cover 2019 through 2026.

## Summary by Sourcery

Documentation:
- Extend the copyright range in LICENSE from 2019 through 2026