### PR TITLE
docs: expand MCP server tool table in README

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,15 +2,15 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [master, develop]
+    branches: [main, develop]
     tags: ["v*", "*"]
   pull_request:
-    branches: [master, develop]
+    branches: [main, develop]
   release:
     types: [published]
   workflow_dispatch:
 
-# Cancel superseded runs on PR / non-master pushes. Tag and master runs are
+# Cancel superseded runs on PR / non-main pushes. Tag and main runs are
 # allowed to complete (publishes must not be cancelled mid-flight).
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -246,7 +246,7 @@ jobs:
   pages-build:
     name: Build docs site
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -267,7 +267,7 @@ jobs:
     name: Deploy docs site
     runs-on: ubuntu-latest
     needs: pages-build
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || github.event_name == 'release' || github.event_name == 'workflow_dispatch')
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.event_name == 'release' || github.event_name == 'workflow_dispatch')
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -287,7 +287,7 @@ jobs:
     name: Publish to TestPyPI
     runs-on: ubuntu-latest
     needs: [build, sbom]
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     environment:
       name: testpypi
       url: https://test.pypi.org/project/tanabesugano/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         - id: ruff-format
           types_or: [python, pyi]
   -   repo: https://github.com/Anselmoo/repo-release-tools
-      rev: v1.8.1
+      rev: v1.8.3
       hooks:
         - id: rrt-branch-name
         - id: rrt-commit-subject

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - update `cicd.yml` to use the correct version of `repo-release-tools` for validating release policies
 - add initial `tree.lock.toml` for dependency management and add screenshot tests to CI/CD pipeline and exclude them from coverage
 - add step to resolve wheel path before generating SPDX SBOM
+- fix update branch references from master to main in CI/CD configuration
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- document all MCP server tools, interactive app tools, and prompts in README (ts_fit_spectrum, ts_nephelauxetic, ts_terms_table_data, and all nine Prefab-UI app tools were previously undocumented)
 - add rrt pre-commit hooks and unified cicd workflow
 - add spectrum fitting tool (`ts_fit_spectrum`) to extract Dq and B parameters from observed UV-Vis absorption peaks
 - add scipy dependency for least-squares optimization in spectrum fitting

--- a/README.md
+++ b/README.md
@@ -280,14 +280,37 @@ Every release attaches a `tanabesugano-<version>.mcpb` artifact (built by the [`
 
 ### Exposed tools
 
+#### Compute & analysis tools
+
 | Tool | Description |
 |---|---|
-| `ts_supported_configs` | List supported d-configurations (d² – d⁸). |
+| `ts_supported_configs` | List supported d-configurations (d²–d⁸). |
 | `ts_compute` | Eigenvalues at one (Dq, B, C) point. |
 | `ts_diagram` | Swept Tanabe-Sugano diagram (JSON). |
+| `ts_terms_table_data` | All eigenvalues at one Dq, sorted ascending with multiplicity. |
+| `ts_fit_spectrum` | Fit observed UV-Vis absorption peaks → Dq and Racah B. |
+| `ts_nephelauxetic` | Interpret a fitted B as metal-ligand covalency (nephelauxetic β). |
 | `ts_plot_png` | Matplotlib PNG plot (cheap default). |
 | `ts_plot_view` | Interactive Prefab `LinePlot` (capable clients only). |
 | `ts_explain` | One-paragraph ground-state description. |
+
+#### Interactive app tools (Prefab UI — capable clients only)
+
+| App | Description |
+|---|---|
+| `ts_explore_app` | Discovery form: entry point that dispatches into the diagram app. |
+| `ts_dashboard_app` | One-call overview of all d-configurations with ground terms. |
+| `ts_diagram_app` | Full diagram with LineChart + DataTable + live Dq slider. |
+| `ts_compare_app` | Small-multiple grid comparing chosen d-configurations. |
+| `ts_overlay_app` | Overlay multiple d-configurations on one shared chart. |
+| `ts_parameter_heatmap_app` | Heatmap sweeping Racah B × C at fixed Dq for a chosen term. |
+| `ts_spectrum_app` | Simulated Lorentzian UV-Vis spectrum (spin-allowed + spin-forbidden). |
+| `ts_reverse_fit_app` | Grid-search Dq and B to best-fit observed peak positions. |
+| `ts_ratio_fit_app` | Derive Dq and B from 2–3 measured bands via the ratio method. |
+
+#### Prompts & resources
+
+Prompts: `tanabesugano_why` (discovery context) and `tanabesugano_explain_complex` (guided spectrum interpretation from measured absorption peaks).
 
 Resources at `tanabesugano://version`, `tanabesugano://configs`, `tanabesugano://config/{d}` provide static metadata.
 


### PR DESCRIPTION
Add all tools, interactive app tools, and prompts introduced since the original MCP section was written — ts_fit_spectrum, ts_nephelauxetic, ts_terms_table_data, and the nine Prefab-UI app tools were undocumented. Restructure the flat table into three grouped subsections.

## Summary by Sourcery

Document newly added MCP server tools and prompts in the README and bump the repo-release-tools pre-commit hook version.

Build:
- Update repo-release-tools pre-commit hook to version v1.8.3.

Documentation:
- Expand the MCP server README section to cover all compute tools, interactive Prefab UI app tools, and available prompts, reorganized into grouped subsections.