### PR TITLE
chore: bump version to v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-06-07
 ### Removed
 - `ts_parameter_heatmap_app`: a fixed-Dq sweep of Racah (B, C) of a single eigenvalue is not a standard coordination-chemistry visualisation (absent from Cotton, Figgis & Hitchman, Bertini, Lever) and the default user call against a ground-term level trivially returned 0 cm⁻¹ everywhere (user-reported uniformly dark heatmap for `d8 3_A_2 level 0 at Dq=900`). Replaced by three TS-companion tools (`ts_orgel_diagram_app` shipped now; `ts_spin_crossover_app` and `ts_correlation_diagram_app` follow)
 - `ts_explore_app`: the Prefab `Form.from_model` rendered as a frozen panel in Claude Desktop, and its `on_submit=CallTool(tool="ts_diagram_app")` wiring went stale after `ts_diagram_app` migrated to the Chart.js `ToolResult` path (the form's submit no longer matched a Prefab-state consumer). Discovery now goes through the `tanabesugano_why` / `tanabesugano_explain_complex` prompts or `ts_supported_configs` → `ts_diagram_app`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tanabesugano"
-version = "1.6.1"
+version = "1.7.0"
 description = "A python-solver for Tanabe-Sugano and Energy-Correlation diagrams"
 authors = [{ name = "Anselm Hahn", email = "anselm.hahn@gmail.com" }]
 maintainers = [{ name = "Anselm Hahn", email = "anselm.hahn@gmail.com" }]

--- a/src/tanabesugano/__init__.py
+++ b/src/tanabesugano/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import annotations
 
 
-__version__ = "1.6.1"
+__version__ = "1.7.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2229,7 +2229,7 @@ wheels = [
 
 [[package]]
 name = "tanabesugano"
-version = "1.6.1"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary by Sourcery

Bump project version to 1.7.0 and document the release in the changelog.

Build:
- Update package metadata and exported __version__ to 1.7.0 in project configuration and module init file.

Documentation:
- Add 1.7.0 release entry to the changelog describing removal of deprecated TS apps and their replacements.