### PR TITLE
fix(mcp): use app.callServerTool() for PNG send-to-chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- PNG export ("Send PNG to chat" button) was silently failing with "Send failed": the iframe JavaScript called `app.callTool()` but the MCP Apps SDK exposes `app.callServerTool()` — renamed to the correct method
+
 ### Removed
 - `ts_parameter_heatmap_app`: a fixed-Dq sweep of Racah (B, C) of a single eigenvalue is not a standard coordination-chemistry visualisation (absent from Cotton, Figgis & Hitchman, Bertini, Lever) and the default user call against a ground-term level trivially returned 0 cm⁻¹ everywhere (user-reported uniformly dark heatmap for `d8 3_A_2 level 0 at Dq=900`). Replaced by three TS-companion tools (`ts_orgel_diagram_app` shipped now; `ts_spin_crossover_app` and `ts_correlation_diagram_app` follow)
 - `ts_explore_app`: the Prefab `Form.from_model` rendered as a frozen panel in Claude Desktop, and its `on_submit=CallTool(tool="ts_diagram_app")` wiring went stale after `ts_diagram_app` migrated to the Chart.js `ToolResult` path (the form's submit no longer matched a Prefab-state consumer). Discovery now goes through the `tanabesugano_why` / `tanabesugano_explain_complex` prompts or `ts_supported_configs` → `ts_diagram_app`

--- a/src/tanabesugano/mcp/apps.py
+++ b/src/tanabesugano/mcp/apps.py
@@ -2006,7 +2006,7 @@ _DIAGRAM_HTML = """<!DOCTYPE html>
     // Both buttons rely on Chart.js' built-in ``toBase64Image()`` to capture
     // the current canvas, but they exit the sandbox in different ways:
     //
-    //   * "Send PNG to chat" calls back via ``app.callTool('ts_emit_png')``
+    //   * "Send PNG to chat" calls back via ``app.callServerTool('ts_emit_png')``
     //     so the server echoes the PNG as ImageContent in the conversation.
     //     This is the only spec-compliant way to get a file *out* of the
     //     iframe: the MCP Apps spec deliberately omits a "downloads"
@@ -2022,7 +2022,7 @@ _DIAGRAM_HTML = """<!DOCTYPE html>
         const dataUrl = chart.toBase64Image('image/png', 1.0);
         const b64 = (dataUrl.split(',', 2)[1] || dataUrl);
         showFlash('Sending…');
-        await app.callTool({ name: 'ts_emit_png', arguments: { png_base64: b64, title: lastTitle } });
+        await app.callServerTool({ name: 'ts_emit_png', arguments: { png_base64: b64, title: lastTitle } });
         showFlash('Sent to chat');
       } catch (e) {
         showFlash('Send failed', true);

--- a/src/tanabesugano/test/test_mcp.py
+++ b/src/tanabesugano/test/test_mcp.py
@@ -167,7 +167,7 @@ def test_ui_resources_request_clipboard_write_permission() -> None:
 
 def test_ts_emit_png_echoes_image_content() -> None:
     """The in-iframe "Send PNG to chat" button calls back via
-    ``app.callTool('ts_emit_png', {png_base64})`` to push the rendered
+    ``app.callServerTool('ts_emit_png', {png_base64})`` to push the rendered
     chart back into the conversation as an MCP image attachment — this
     is the only spec-compliant export path (the MCP Apps sandbox has no
     "downloads" permission, so ``<a download>`` is suppressed). Pin the


### PR DESCRIPTION
## Summary

- `app.callTool()` does not exist in the MCP Apps SDK — the correct method is `app.callServerTool({ name, arguments })` (see [FastMCP low-level apps docs](https://gofastmcp.com/apps/low-level))
- Every click on the **Send PNG to chat** toolbar button immediately threw an exception and showed `Send failed` in the flash message
- Also updates the comment and test docstring that referenced the wrong method name

## Test plan

- [ ] Open any Chart.js app tool (`ts_diagram_app`, `ts_overlay_app`, etc.) in Claude Desktop
- [ ] Click **Send PNG to chat** — should show `Sending…` then `Sent to chat`, and the PNG appears inline in the conversation
- [ ] Unit test `test_ts_emit_png_echoes_image_content` continues to pass (the tool contract is unchanged; only the JS call site is fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix PNG send-to-chat callback in the MCP app iframe to use the correct MCP Apps SDK API so PNG exports succeed.

Bug Fixes:
- Correct the in-iframe PNG export button to call `app.callServerTool` instead of the non-existent `app.callTool`, restoring successful PNG send-to-chat behavior.

Documentation:
- Align inline comments, test docstring, and changelog notes with the correct `app.callServerTool` API for PNG export.