### PR TITLE
chore: switch mcpb CI job to mcp2mcpb --from-dist (v0.5)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -151,32 +151,22 @@ jobs:
   mcpb:
     name: Build .mcpb bundle
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [build]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Download wheel
+        uses: actions/download-artifact@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - run: python scripts/build_mcpb.py
-      - name: Validate .mcpb archive
-        run: |
-          python - <<'PY'
-          import glob, json, sys, zipfile
-          paths = glob.glob("dist/*.mcpb")
-          if not paths:
-              sys.exit("No .mcpb file found in dist/")
-          path = paths[0]
-          with zipfile.ZipFile(path) as zf:
-              names = zf.namelist()
-              for required in ("manifest.json", "server/main.py"):
-                  if required not in names:
-                      sys.exit(f"Missing required archive member: {required}")
-              manifest = json.loads(zf.read("manifest.json"))
-          assert manifest["name"] == "tanabesugano", manifest
-          assert manifest["server"]["type"] == "uv", manifest
-          assert manifest["server"]["mcp_config"]["command"] == "uv", manifest
-          print(f"OK: {path}")
-          PY
+          name: python-package-distributions
+          path: dist/
+      - name: Build .mcpb bundle
+        uses: Anselmoo/mcp2mcpb@v0.5
+        with:
+          package: tanabesugano
+          registry: pypi
+          mode: reference
+          from-dist: dist/
+          attach-to-release: 'false'
       - uses: actions/upload-artifact@v4
         with:
           name: mcpb-package

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -160,7 +160,7 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Build .mcpb bundle
-        uses: Anselmoo/mcp2mcpb@v0.5
+        uses: Anselmoo/mcp2mcpb@b040babc466902b721e2367d2e5611908c3603d8
         with:
           package: tanabesugano
           registry: pypi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- CI/CD: switch mcpb job to use `Anselmoo/mcp2mcpb@v0.5` composite action with `--from-dist` to build bundles from locally-built wheel
 
 ## [1.7.1] - 2026-06-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Changed
-- CI/CD: switch mcpb job to use `Anselmoo/mcp2mcpb@v0.5` composite action with `--from-dist` to build bundles from locally-built wheel
+- CI/CD: switch mcpb job to use `Anselmoo/mcp2mcpb` composite action with `--from-dist` to build bundles from locally-built wheel (pinned to SHA `b040bab` — pre-release v0.5)
 
 ## [1.7.1] - 2026-06-10
 ### Fixed


### PR DESCRIPTION
## Summary

- Replaces the custom `scripts/build_mcpb.py` call in the `mcpb` CI job with the official `Anselmoo/mcp2mcpb@v0.5` composite action
- Changes `needs: lint` → `needs: [build]` so the wheel is available before bundling
- Adds a `download-artifact@v4` step to fetch the built wheel into `dist/`
- Uses `from-dist: dist/` — version is read from the wheel's own METADATA, so releasing v1.8.0 always produces `tanabesugano-1.8.0.mcpb`
- `scripts/build_mcpb.py` retained for local dev use (`--dev` flag)

## Test plan

- [ ] CI passes the `mcpb` job on this PR
- [ ] On a tag push: verify `release-assets` job attaches the correctly-versioned `.mcpb` to the GitHub Release
- [ ] `dist/` in the job log shows `*.whl` before the mcp2mcpb step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the mcpb CI job to build the .mcpb bundle from the wheel artifact using the official mcp2mcpb composite action instead of the custom script.

CI:
- Change the mcpb job to depend on the build job, download the built wheel artifact, and invoke Anselmoo/mcp2mcpb@v0.5 with from-dist to generate the .mcpb bundle.

Documentation:
- Document the CI/CD change in the Unreleased changelog section.