### PR TITLE
docs: repair broken README badges and links, add a 2.0.0 upgrade section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ### 📊 Build & Quality
 
-[![Python Package](https://github.com/Anselmoo/TanabeSugano/actions/workflows/python-package.yml/badge.svg)](https://github.com/Anselmoo/TanabeSugano/actions/workflows/python-package.yml)
+[![CI/CD](https://github.com/Anselmoo/TanabeSugano/actions/workflows/cicd.yml/badge.svg)](https://github.com/Anselmoo/TanabeSugano/actions/workflows/cicd.yml)
 [![CodeFactor](https://www.codefactor.io/repository/github/anselmoo/tanabesugano/badge)](https://www.codefactor.io/repository/github/anselmoo/tanabesugano)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 
@@ -24,8 +24,8 @@
 ### 📚 Resources
 
 [![DOI](https://zenodo.org/badge/206847682.svg)](https://zenodo.org/badge/latestdoi/206847682)
-[![GitHub](https://img.shields.io/github/license/Anselmoo/TanabeSugano)](https://github.com/Anselmoo/TanabeSugano/blob/master/LICENSE)
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Anselmoo/TanabeSugano/blob/master/Tanabe_Sugano.ipynb)
+[![GitHub](https://img.shields.io/github/license/Anselmoo/TanabeSugano)](https://github.com/Anselmoo/TanabeSugano/blob/main/LICENSE)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Anselmoo/TanabeSugano/blob/main/Tanabe_Sugano.ipynb)
 
 ---
 
@@ -41,6 +41,7 @@
 ## 📋 Table of Contents
 
 - [Overview](#-overview)
+- [Upgrading to 2.0.0](#-upgrading-to-200)
 - [Quick Start](#-quick-start)
 - [Features](#-features)
 - [Usage](#-usage)
@@ -64,6 +65,21 @@
 - 🔄 **Interactive Exploration** - Explore diagrams with Plotly integration
 - 🚀 **Easy to Use** - Simple CLI and Python API
 - 📱 **Cloud-Ready** - Run in Google Colab or locally
+
+---
+
+## 🔄 Upgrading to 2.0.0
+
+**2.0.0 is a breaking release.** Three changes bite existing users; the full list is in
+[`CHANGELOG.md`](CHANGELOG.md).
+
+| What changed | Migration |
+|---|---|
+| `matrices.dN.solver()` returns a **`LevelSet`**, not `dict[TermKey, Float64Array]`. `LevelSet` is *not* a Mapping — `states[key]`, `.items()` and `len()` raise `TypeError`. | Call `.as_dict()` for the old shape, or iterate `.levels`. A bare dict could not express a multiplet: for d⁸ it mapped `3_T_1` to a two-element array, so ν₂ and ν₃ were indistinguishable. |
+| **Term keys renamed**: `1_T_3` → `1_T_2` (no T₃ irrep exists in O<sub>h</sub>) and `*_E_1` → `*_E` (E<sub>g</sub> carries no subscript). | Update any literal key match. `TermKey` now makes both old spellings unwritable. This also renames the corresponding **CSV columns** in `ts-diagrams/**`. |
+| **Committed CSV artifacts changed.** `delta_B` held `Dq/B` while labelled `Δ/B` and is now **10× larger** (the old values were wrong); the cm⁻¹→eV factor was `0.00012` and is now `1/8065.54`; columns are renamed as above and now sorted rather than dict-insertion ordered. | Re-read any pinned column indices by name. Values are otherwise unchanged — verified cell-by-cell across all 42 regenerated files, and now guarded by a `--check` step in CI. |
+
+Python ≥ 3.12 is required.
 
 ---
 
@@ -101,7 +117,7 @@ tanabesugano -d 6
 tanabesugano -d 6 -Dq 8000 -B 860 1.0 -C 3850 1.0
 ```
 
-**🎮 Try it now:** [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Anselmoo/TanabeSugano/blob/master/Tanabe_Sugano.ipynb)
+**🎮 Try it now:** [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Anselmoo/TanabeSugano/blob/main/Tanabe_Sugano.ipynb)
 
 ---
 
@@ -254,7 +270,7 @@ High-quality diagram for d<sup>6</sup> configuration with B = 860 cm⁻¹ and C 
 
 <div align="center">
 
-![Tanabe-Sugano Diagram for d6](https://github.com/Anselmoo/TanabeSugano/blob/master/examples/dd-diagram_for_d6.png?raw=true)
+![Tanabe-Sugano Diagram for d6](https://github.com/Anselmoo/TanabeSugano/blob/main/examples/dd-diagram_for_d6.png?raw=true)
 
 *Figure: Tanabe-Sugano diagram showing energy levels as a function of crystal field strength*
 
@@ -266,7 +282,7 @@ Interactive diagram for d<sup>6</sup> with Slater-Condon parameters F² = 1065 c
 
 <div align="center">
 
-![Interactive Tanabe-Sugano Diagram](https://github.com/Anselmoo/TanabeSugano/blob/master/examples/d6_ts_interactive.gif?raw=true)
+![Interactive Tanabe-Sugano Diagram](https://github.com/Anselmoo/TanabeSugano/blob/main/examples/d6_ts_interactive.gif?raw=true)
 
 *Figure: Interactive diagram with hover tooltips and zoom capabilities*
 
@@ -420,14 +436,20 @@ If you use TanabeSugano in your research, please cite:
 
 ```bibtex
 @software{tanabesugano,
-  author       = {Anselm Hahn},
+  author       = {Hahn, Anselm W.},
   title        = {TanabeSugano: Python-based Eigensolver for Tanabe-Sugano Diagrams},
-  year         = {2024},
+  year         = {2026},
   publisher    = {Zenodo},
-  doi          = {10.5281/zenodo.206847682},
+  version      = {2.0.0-alpha.1},
+  doi          = {10.5281/zenodo.3402463},
   url          = {https://github.com/Anselmoo/TanabeSugano}
 }
 ```
+
+> **Which DOI?** `10.5281/zenodo.3402463` is the *concept* DOI — it always resolves to the
+> newest deposited release, which is what you want in a reference list. To cite the exact
+> version you ran, use that release's own version DOI from the
+> [Zenodo record](https://doi.org/10.5281/zenodo.3402463) instead.
 
 [![DOI](https://zenodo.org/badge/206847682.svg)](https://zenodo.org/badge/latestdoi/206847682)
 
@@ -447,6 +469,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 [Report Bug](https://github.com/Anselmoo/TanabeSugano/issues) ·
 [Request Feature](https://github.com/Anselmoo/TanabeSugano/issues) ·
-[Discussions](https://github.com/Anselmoo/TanabeSugano/discussions)
+[Interactive Diagrams](https://anselmoo.github.io/TanabeSugano/)
 
 </div>


### PR DESCRIPTION
## Summary

Three things in the README were **verifiably broken**, each confirmed over the network rather than by inspection. A fourth class was not a 404 but was silently serving stale content.

## Hard breakage (HTTP 404)

| Problem | Evidence | Fix |
|---|---|---|
| CI badge pointed at `actions/workflows/python-package.yml` | that workflow no longer exists — the workflow is `cicd.yml`. Badge URL returns **404**; `cicd.yml` returns **200** | repointed, relabelled `CI/CD` |
| Citation BibTeX carried `doi = {10.5281/zenodo.206847682}` | `206847682` is the **GitHub repository id**, not a Zenodo record. `https://doi.org/10.5281/zenodo.206847682` → **404** | → `10.5281/zenodo.3402463` (concept DOI, **200**) |
| Footer linked to `/discussions` | **404** — Discussions is not enabled on this repository | repointed at the interactive diagrams site |

The DOI is the one that actually cost something: anyone who copied that BibTeX into a paper published a reference that resolves to nothing. It is also the kind of breakage a link-checker misses, because the *badge image* (`zenodo.org/badge/206847682.svg`) returns 200 perfectly well — the dead artifact was the DOI inside the fenced BibTeX block, which nothing renders and nothing fetches.

## Silent staleness — five `blob/master/` links

Not 404s. `master` still exists, so they resolve — but it is frozen at **2026-06-06, twelve commits behind `main`**. `examples/dd-diagram_for_d6.png` changed in the 2.0.0 commit, so the README was rendering the *old, pre-`plot_style`* screenshot (the one with the macOS title bar). All five now use `main`.

## Added: "Upgrading to 2.0.0"

2.0.0 is a breaking release, and the breaking `delta_B` change (10× larger — the old values were wrong) plus the CSV column renames affect downstream consumers who would never scroll as far as the Python API note. A short table near the top covers the `LevelSet` return type, the term-key renames, and the CSV artifact changes, pointing at `CHANGELOG.md` for the rest.

Citation metadata now also matches `CITATION.cff`: author with initial, year 2026, explicit version.

## Verification

- `test_readme_examples.py` **passes** — it executes every ` ```python ` block in this file, so the code samples are proven, not assumed
- **All 34 URLs** in the README were fetched; all resolve except the three JPS publisher links, which return **403 to any non-browser client** (Cloudflare challenge). Those DOIs are registered in Crossref and their volume / page / year match the README exactly — so they are correct and deliberately left alone
- All 11 ToC anchors resolve against real headings. The new heading uses a single-codepoint emoji rather than `⚠️`, whose `U+FE0F` variation selector makes GitHub's anchor fragile
- `pre-commit` clean, including `ty` and `rrt-branch-name`

## Follow-up, not in this PR

`CITATION.cff` still pins `doi: 10.5281/zenodo.7751230` — a *version* DOI for an older release — which now disagrees with the README's concept DOI. Both resolve, but they should probably agree. Left out because changing release-tracked citation metadata is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the README for reliable navigation, current links, accurate citation metadata, and 2.0.0 migration guidance.

New Features:
- Add a concise 2.0.0 upgrade guide covering breaking API, term-key, CSV, and Python version changes.

Bug Fixes:
- Repair broken CI, citation, and footer links and update stale repository links to the main branch.
- Correct README citation metadata and document concept-versus-version DOI usage.