### PR TITLE
docs(changelog): backfill Unreleased entry for README fixes (#197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 ## [Unreleased]
+### Documentation
+
+- Repaired three broken README links: the CI badge pointed at a workflow
+  file (`python-package.yml`) that no longer exists — the workflow is now
+  `cicd.yml`; the citation BibTeX carried the GitHub repository id as a
+  Zenodo DOI (`10.5281/zenodo.206847682`), which 404s, replaced with the
+  resolving concept DOI `10.5281/zenodo.3402463`; and the footer linked to
+  `/discussions`, which 404s because Discussions is not enabled, repointed at
+  the interactive diagrams site. Also added a 2.0.0 upgrade section
 
 ## [2.0.0-alpha.1] - 2026-08-20
 ### Changed


### PR DESCRIPTION
## Summary
- Fixes the `Lint & Policy` failure in [run 32450598224](https://github.com/Anselmoo/TanabeSugano/actions/runs/32450598224): `rrt-hooks check-changelog` rejected the `v2.0.0-alpha.1` tag push because commit `2996765` ("docs: repair broken README badges and links, add a 2.0.0 upgrade section", #197) is a `docs:` commit — rrt's policy maps `docs` to the "Documentation" changelog section (not "Maintenance", unlike `chore`/`ci`/`build`) — but never added a `CHANGELOG.md` entry.
- Backfills a `### Documentation` bullet under `[Unreleased]` summarizing the three README fixes from #197 (CI badge target, Zenodo DOI, discussions link).

## Root cause
`SECTION_MAP` in `repo_release_tools/changelog.py` requires a changelog entry for every conventional-commit type except `chore`/`ci`/`build`/`test`/`deps` (mapped to "Maintenance"). `docs` maps to "Documentation", so it is changelog-relevant. #197 was merged without touching `CHANGELOG.md`, tripping the policy gate on the next tag push.

## Test plan
- [x] `uv run pre-commit run --files CHANGELOG.md` — `repo-release-tools changelog` hook passes
- [x] Reproduced the original failure locally via `rrt-hooks check-changelog --subject "docs: repair broken README badges and links, add a 2.0.0 upgrade section (#197)" --changed-file README.md` and confirmed the fix resolves it

## Summary by Sourcery

Documentation:
- Backfill the Unreleased Documentation changelog entry for the README link and badge repairs, including the 2.0.0 upgrade guidance.