### PR TITLE
fix(docs): add vite-env.d.ts to type CSS side-effect imports

### DIFF
--- a/.rrt/tree.lock.toml
+++ b/.rrt/tree.lock.toml
@@ -1,10 +1,10 @@
 [meta]
-generated_at = "2026-08-22T12:05:05+00:00"
+generated_at = "2026-08-22T18:36:29+00:00"
 rrt_version = "1.15.0"
 
 [snapshot]
-entry_count = 213
-tree_hash = "sha256:0ad3cde3c1faaf2182e8dc8645d4412cee5818d188296c33262c086b399d3319"
-updated_at = "2026-08-22T12:05:05+00:00"
-ignored_count = 7
+entry_count = 214
+tree_hash = "sha256:96115ceda6d6a450d5e299280e24558e89cc0201a5b780a49616f67d3956621f"
+updated_at = "2026-08-22T18:36:29+00:00"
+ignored_count = 4
 phantom_empty_dirs = []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   `App.css` and `index.css`: the app had no ambient module declaration for
   CSS imports. Added `docs/src/vite-env.d.ts` with the standard
   `/// <reference types="vite/client" />`, already covered by
-  `docs/tsconfig.json`'s `src` include
+  `docs/tsconfig.json`'s `src` include. Refreshed `.rrt/tree.lock.toml`
+  (213 -> 214 entries) so CI's tree drift gate accounts for the new file
 
 ## [2.0.0-alpha.2] - 2026-08-22
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- `docs/` build failed `tsc` with `TS2882` on the side-effect imports of
+  `App.css` and `index.css`: the app had no ambient module declaration for
+  CSS imports. Added `docs/src/vite-env.d.ts` with the standard
+  `/// <reference types="vite/client" />`, already covered by
+  `docs/tsconfig.json`'s `src` include
 
 ## [2.0.0-alpha.2] - 2026-08-22
 ### Changed

--- a/docs/src/vite-env.d.ts
+++ b/docs/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- `docs/` build was failing `tsc` with `TS2882` on the side-effect imports of `App.css` (`App.tsx`) and `index.css` (`main.tsx`) — TypeScript had no ambient module declaration for CSS imports.
- Added `docs/src/vite-env.d.ts` with the standard `/// <reference types="vite/client" />`. `docs/tsconfig.json` already includes `src`, so it's picked up automatically — no tsconfig change needed.
- Added a CHANGELOG entry.

## Test plan
- [x] `npx tsc --noEmit` in `docs/` completes with no errors
- [x] `npm run build` (`tsc && vite build`) in `docs/` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restore successful documentation builds by providing ambient Vite typings for imported CSS files.

Bug Fixes:
- Fix the docs TypeScript build by adding Vite type declarations for CSS side-effect imports.

Build:
- Update the repository tree lock to include the new Vite environment declaration file.