### PR TITLE
fix(ci): skip commit-subject policy check on tag pushes

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -97,7 +97,14 @@ jobs:
         uses: Anselmoo/repo-release-tools@v1.15.0
         with:
           check-branch-name: "true"
-          check-commit-subject: "true"
+          # Tags point at an already-merged squash commit whose subject is
+          # the PR title, decided at merge time -- there is nothing left to
+          # act on by the time a tag triggers this job, and the subject
+          # can't be fixed after the fact without rewriting public history.
+          # Only lint it while it's still actionable, on the PR's own head
+          # commit. check-branch-name already self-exempts tag refs the same
+          # way internally.
+          check-commit-subject: ${{ github.event_name == 'pull_request' }}
           check-changelog: "true"
           changelog-strategy: "auto"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- CI's `Validate release policy (rrt)` step no longer runs
+  `check-commit-subject` on tag pushes. A tag points at an already-merged
+  squash commit whose subject is fixed at merge time; linting it again on
+  tag push blocked the whole release pipeline (`lint` gates `test` → `build`
+  → `mcpb`/`publish-pypi`/`release`) for a finding no one could still act on.
+  The check still runs on `pull_request` events, where it's actionable.
 
 ## [2.0.0-beta.1] - 2026-08-23
 ### Added


### PR DESCRIPTION
## Summary
- `Validate release policy (rrt)` runs on both `pull_request` and tag-push events. `check-commit-subject` unconditionally lints `git log -1 --pretty=%s` at whatever ref triggered it — on a tag push that's the already-merged squash commit, whose subject is fixed at merge time.
- This just blocked the whole `v2.0.0-beta.1` pipeline: [run 32629165187](https://github.com/Anselmoo/TanabeSugano/actions/runs/32629165187/job/97169229664) failed because PR #201's squash-merge subject ("Fix the MCP layer's presentation defects and release 2.0.0-beta.1 (#201)") isn't Conventional-Commits-formatted. `lint` gates `test` → `build` → `mcpb`/`publish-pypi`/`release`, so nothing downstream could run.
- Restrict `check-commit-subject` to `pull_request` events, where it's still actionable — mirroring how `check-branch-name` already self-exempts tag refs internally (see the job log: "Skipping branch-name validation for tag refs.").

## Note on the stuck v2.0.0-beta.1 tag
This fix won't retroactively rescue that run — GitHub Actions evaluates a tag push against the workflow file as it existed at that tag's commit, not against `main` after this merges. Once merged, the tag will need to be re-cut (or the next tag) against a commit that includes this fix.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/cicd.yml'))"` — valid YAML
- [x] Local pre-commit (including the same `repo-release-tools branch name`/`changelog` hooks) passes
- [ ] CI's `Lint & Policy` job passes on this PR's `pull_request` run (commit-subject check still active there)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0116VPCobbJhFzgrJiuD4hpF

## Summary by Sourcery

Limit commit-subject policy validation to pull request events so tag pushes can proceed through the release pipeline.

Bug Fixes:
- Prevent tag-triggered release pipelines from failing on commit-subject policy violations that cannot be corrected after merge.

CI:
- Run commit-subject validation only for pull request events while retaining actionable policy checks for pull requests.