### PR TITLE
Fix the dashboard sparkline kinks and release 2.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [2.0.0-beta.2] - 2026-08-23
 ### Fixed
 
 - `ts_dashboard_app`'s sparkline plots the band the card claims. It took the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,44 @@
 ## [Unreleased]
 ### Fixed
 
+- `ts_dashboard_app`'s sparkline plots the band the card claims. It took the
+  lowest eigenvalue of *any* multiplicity, so the curve silently changed which
+  transition it tracked mid-sweep — d4 ran ⁵Eg→⁵T₂g until 10Dq ≈ 12 766 cm⁻¹
+  and then switched to the spin-forbidden ⁵Eg→³T₁g, which is what the visible
+  kink was. Selection now goes through the shared `transition_candidates`,
+  which the dashboard was the only surface to bypass, declaring its own
+  threshold twice instead.
+- The card now carries two tabs. **Spin-allowed ν₁** is the lowest band an
+  absorption spectrum actually shows and tracks one transition end to end;
+  **Lowest level (any spin)** keeps the crossing, which is real structure —
+  a spin-forbidden level dropping below the spin-allowed one — and names both
+  branches plus the 10Dq where they swap. Note this is *not* the high-spin →
+  low-spin ground flip: the ground term is high-spin across the whole 50–1500
+  cm⁻¹ window, and the real crossovers sit at 10Dq = 26 386 (d4), 21 348 (d6)
+  and 21 058 (d7). Both series come from the same sweep, so the second costs
+  no extra solve.
+- High-spin d5 has no spin-allowed d-d band at all — ⁶A₁g is the
+  configuration's only sextet — so its card falls back to the lowest
+  spin-forbidden one and says so on a badge. The fallback is never silent.
+- Dashboard captions no longer misreport their own axes. The range was
+  hardcoded `10Dq = 0 → 15 000` while the sweep had been moved to start at
+  Dq = 50, and the endpoints were `min()`/`max()` rather than first/last —
+  which printed d5's descending curve backwards as `15842 → 27808`. Nothing
+  asserted the caption, so both survived; a test now parses the rendered
+  strings.
+- Transition labels on the dashboard use free-ion parentage (`³T₁g(F)`,
+  `⁴T₁g(G)`) rather than the positional ordinal, via `LevelSet.solve` instead
+  of `LevelSet.from_states` — the latter skips parentage derivation and falls
+  back to `(a)`/`(b)`, which appears in no textbook.
+
+### Added
+
+- `nu1 == 10Dq` is now asserted for d4 (`5_T_2`) and d6 (`5_E`) alongside the
+  existing d3/d8 pair. ⁵D is the only quintet in either configuration, so its
+  Eg/T₂g components have nothing to mix with and their separation is exactly
+  Δₒ — group theory, not a measurement of this solver, which is what lets it
+  police the `= 10Dq exactly` badge the dashboard prints.
+
 - CI's `Validate release policy (rrt)` step no longer runs
   `check-commit-subject` on tag pushes. A tag points at an already-merged
   squash commit whose subject is fixed at merge time; linting it again on

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
 - family-names: "thebadgerchemist"
 - family-names: "Imgbot"
 title: "TanabeSugano"
-version: 2.0.0-beta.1
+version: 2.0.0-beta.2
 doi: 10.5281/zenodo.7751230
 date-released: 2026-08-23
 url: "https://github.com/Anselmoo/TanabeSugano"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tanabesugano"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 description = "A python-solver for Tanabe-Sugano and Energy-Correlation diagrams"
 authors = [{ name = "Anselm Hahn", email = "anselm.hahn@gmail.com" }]
 maintainers = [{ name = "Anselm Hahn", email = "anselm.hahn@gmail.com" }]

--- a/src/tanabesugano/__init__.py
+++ b/src/tanabesugano/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import annotations
 
 
-__version__ = "2.0.0-beta.1"
+__version__ = "2.0.0-beta.2"

--- a/src/tanabesugano/mcp/apps.py
+++ b/src/tanabesugano/mcp/apps.py
@@ -25,7 +25,13 @@ from __future__ import annotations
 import logging
 
 from typing import TYPE_CHECKING
+from typing import NamedTuple
 
+from tanabesugano.levels import LevelSet
+from tanabesugano.mcp._compute import compute_point
+from tanabesugano.mcp._compute import sweep_dq
+from tanabesugano.mcp._compute import transition_candidates
+from tanabesugano.mcp._defaults import _DConfig
 from tanabesugano.plot_style import ANNOTATION_COLORS
 from tanabesugano.plot_style import color_for_multiplicity
 
@@ -33,6 +39,36 @@ from tanabesugano.plot_style import color_for_multiplicity
 log = logging.getLogger(__name__)
 
 DIAGRAM_URI = "ui://tanabesugano/diagram.html"
+
+# ── Dashboard band selection ─────────────────────────────────────────────
+_GROUND_FLOOR_CM1 = 1.0
+"""Energy above which an eigenvalue counts as a real excited state.
+
+The solvers zero the ground manifold, so anything at or below this is the
+ground state itself rather than a band. Declared once and threaded into
+``transition_candidates(min_energy_cm1=...)``; ``ts_dashboard_app`` used to
+spell it twice, locally, which is the divergence the shared helpers exist to
+prevent.
+"""
+
+_TEN_DQ_TOL_CM1 = 1e-6
+"""How exactly nu1 must equal 10Dq to earn the '= 10Dq exactly' badge.
+
+Tight because the identity is exact, not approximate: for d3/d4/d6/d8 the Racah
+terms cancel identically and the residual is float noise. Pinned against the
+solver in ``test_matrices_invariants.TestExactTransitionIdentities``.
+"""
+
+_BRANCH_TOL_DQ_CM1 = 0.5
+"""Bisection half-width for the reported branch-change Dq, in cm^-1.
+
+Set from the *display* precision, not measured from the solver: the caption
+rounds 10 * Dq to the nearest 100 cm^-1, so 0.5 in Dq is already an order of
+magnitude finer than anything shown.
+"""
+
+_BRANCH_BISECT_STEPS = 12
+"""Bisection cap. log2(50 / 0.5) ~ 6.6, so this cannot bind at the defaults."""
 
 # Scatter point sizes used to carry spin-allowedness when the landscape is
 # weighted. Sizes, not colours: `plot_style` owns colour, and allowedness is
@@ -457,7 +493,150 @@ def _register_diagram_app(mcp: FastMCP) -> None:
         return ToolResult(content=[_mcp_types.TextContent(type="text", text=payload)])
 
 
-def _first_excited_curve(
+class _BandSeries(NamedTuple):
+    """One sparkline: the energies, and everything needed to caption them.
+
+    ``label`` is the *parentage* spelling (``3T1g(F)``), not the positional
+    ordinal (``3T1g(a)``) -- see :meth:`LevelSet.display_labels`. ``switch_*``
+    are populated only for a series that changes branch mid-sweep, which after
+    the spin-allowed filter is true of ``any_spin`` alone.
+    """
+
+    values: list[float]
+    label: str
+    spin_allowed: bool
+    is_ten_dq: bool
+    ref_energy: float = 0.0
+    ref_dq: float = 0.0
+    switch_label: str | None = None
+    switch_dq: float | None = None
+
+    def label_at(self, dq: float) -> str:
+        """The branch actually plotted at ``dq`` -- the second one past a switch."""
+        if self.switch_dq is not None and self.switch_label and dq >= self.switch_dq:
+            return self.switch_label
+        return self.label
+
+
+class _DashboardBands(NamedTuple):
+    """Both series a dashboard card can plot, from a single Dq sweep."""
+
+    dq_values: list[float]
+    spin_allowed: _BandSeries
+    any_spin: _BandSeries
+
+
+def _branch_of(term_energies: dict[str, list[float]], *, spin_allowed_only: bool) -> str | None:
+    """Positional assignment of the lowest candidate band, or ``None`` if there is none.
+
+    Positional (``4_T_1(a)``) on purpose: this string is an *identity* used to
+    detect a branch change, never displayed. Parentage is not injective -- d4,
+    d5 and d6 each hold level pairs whose parent labels are byte-identical --
+    so comparing parentage strings would miss a real crossing.
+    """
+    _ground, candidates = transition_candidates(
+        term_energies,
+        spin_allowed_only=spin_allowed_only,
+        min_energy_cm1=_GROUND_FLOOR_CM1,
+    )
+    return candidates[0][1] if candidates else None
+
+
+def _display_transition(
+    d_count: int, dq: float, B: float, C: float, *, spin_allowed_only: bool
+) -> tuple[str, bool]:
+    """Return ``(parentage label, is_spin_allowed)`` for the lowest band at ``dq``.
+
+    Goes through :meth:`LevelSet.solve` rather than :meth:`LevelSet.from_states`
+    because only ``solve`` derives free-ion parentage; ``from_states`` falls back
+    to the positional ordinal and would print ``3T1g(a)`` where the literature
+    writes ``3T1g(F)``. One extra solve per card, against the 30 the sweep pays.
+
+    When ``spin_allowed_only`` is asked for but no spin-allowed band exists --
+    high-spin d5, whose 6A1g is the configuration's only sextet -- this falls
+    back to the lowest level of any multiplicity and returns ``False`` so the
+    caller can say so. The fallback is never silent.
+    """
+    manifold = LevelSet.solve(d_count, dq, B, C)
+    labels = manifold.display_labels("unicode")
+    allowed = manifold.spin_allowed()
+    if spin_allowed_only and allowed:
+        return f"{labels[manifold.ground.uid]} → {labels[allowed[0].uid]}", True
+    excited = next(
+        (lv for lv in manifold.levels if lv.energy_cm1 > _GROUND_FLOOR_CM1),
+        None,
+    )
+    if excited is None:  # pragma: no cover - every configuration has excited levels
+        return labels[manifold.ground.uid], False
+    return f"{labels[manifold.ground.uid]} → {labels[excited.uid]}", not spin_allowed_only
+
+
+def _bisect_branch_change(
+    d_count: int,
+    B: float,
+    C: float,
+    lo: float,
+    hi: float,
+    lo_branch: str | None,
+    *,
+    spin_allowed_only: bool,
+) -> float:
+    """Dq at which the plotted band changes branch, within ``lo..hi``.
+
+    Bisected to :data:`_BRANCH_TOL_DQ_CM1` rather than reported as the grid
+    bracket, so the caption can name a number instead of a 50 cm^-1 window.
+    Costs ~10 solves and only for the configurations that actually cross.
+    """
+    for _ in range(_BRANCH_BISECT_STEPS):
+        mid = (lo + hi) / 2.0
+        branch = _branch_of(compute_point(d_count, mid, B, C), spin_allowed_only=spin_allowed_only)
+        if branch == lo_branch:
+            lo = mid
+        else:
+            hi = mid
+        if hi - lo <= _BRANCH_TOL_DQ_CM1:
+            break
+    return hi
+
+
+def _find_branch_change(
+    d_count: int,
+    B: float,
+    C: float,
+    dq_values: list[float],
+    branches: list[str | None],
+    *,
+    spin_allowed_only: bool,
+) -> tuple[str | None, float | None]:
+    """``(label after the change, Dq of the change)``, or ``(None, None)``.
+
+    Run for **both** series, not just ``any_spin``. An earlier draft computed it
+    only for ``any_spin`` and left ``spin_allowed.switch_dq`` hardcoded to
+    ``None`` -- which made the kink-guard test assert a constant and pass no
+    matter what the filter did. A mutation that disabled spin-allowed filtering
+    entirely survived it. The guard only has teeth if this value is derived on
+    the same path the test reads.
+    """
+    for i in range(1, len(branches)):
+        if branches[i] == branches[i - 1]:
+            continue
+        switch_dq = _bisect_branch_change(
+            d_count,
+            B,
+            C,
+            dq_values[i - 1],
+            dq_values[i],
+            branches[i - 1],
+            spin_allowed_only=spin_allowed_only,
+        )
+        label, _ = _display_transition(
+            d_count, dq_values[-1], B, C, spin_allowed_only=spin_allowed_only
+        )
+        return label, switch_dq
+    return None, None
+
+
+def _dashboard_bands(
     d_count: int,
     B: float,
     C: float,
@@ -465,26 +644,36 @@ def _first_excited_curve(
     dq_min: float | None = None,
     dq_max: float = 1500.0,
     steps: int = 30,
-    ground_eps: float = 1.0,
-) -> list[float]:
-    """Lowest eigenvalue above the ground manifold at each Dq of a sweep.
+    ref_dq: float = 1000.0,
+) -> _DashboardBands:
+    """Both dashboard series for one configuration, from a single Dq sweep.
 
-    Extracted from ``ts_dashboard_app`` so the curve can be asserted on
-    directly; the tool body renders whatever this returns.
+    The two series answer two different questions and the card used to conflate
+    them. ``spin_allowed`` is nu1 -- the lowest band an absorption spectrum
+    actually shows -- and tracks one transition end to end. ``any_spin`` is the
+    lowest level of *any* multiplicity, a structural quantity whose kink marks a
+    spin-forbidden level dropping below the spin-allowed one (d4 at 10Dq ~
+    12 800, d6 ~ 13 800, d7 ~ 11 200, d2 at the very last step).
 
-    ``ground_eps`` is the threshold above which an eigenvalue counts as a real
-    excited state -- the solvers zero the ground manifold, so anything at or
-    below it is the ground state itself rather than a band.
+    That kink is **not** the HS -> LS ground flip: the ground term is high-spin
+    and constant across this whole window, and the real crossovers sit at 10Dq =
+    26 386 (d4), 21 348 (d6) and 21 058 (d7), far outside it.
 
-    ``dq_min`` defaults to one grid step, **not** to zero, and that is the
-    whole point of the parameter. At Dq = 0 the ligand field vanishes and every
+    Both series are read off the same ``sweep_dq`` points, so the second one
+    costs no extra solve. Selection goes through the shared
+    :func:`~tanabesugano.mcp._compute.transition_candidates`; the dashboard used
+    to roll its own threshold twice, which is exactly what the note at the head
+    of ``_compute``'s shared-helpers section forbids.
+
+    ``dq_min`` defaults to one grid step, **not** to zero, and that is the whole
+    point of the parameter. At Dq = 0 the ligand field vanishes and every
     octahedral component of the free-ion ground term is exactly degenerate, so
-    the entire ground manifold sits inside ``ground_eps``; the search for "the
-    first level above it" then falls through to the next free-ion term
-    altogether and reports a gap tens of thousands of cm-1 above the curve it
-    belongs to. Measured at the defaults, that put the first point 26x-48x
-    above the second for every configuration except d5 -- whose 6S ground term
-    is an orbital singlet, has nothing to split, and never spiked.
+    the entire ground manifold sits inside the floor; the search for "the first
+    level above it" then falls through to the next free-ion term altogether and
+    reports a gap tens of thousands of cm-1 above the curve it belongs to.
+    Measured at the defaults, that put the first point 26x-48x above the second
+    for every configuration except d5 -- whose 6S ground term is an orbital
+    singlet, has nothing to split, and never spiked.
 
     Deriving the offset as ``dq_max / steps`` rather than hardcoding it keeps
     the grid uniform for any sweep: with the defaults the points fall on
@@ -493,15 +682,184 @@ def _first_excited_curve(
     have silenced the symptom too, but it would hand the caller one point fewer
     than they asked for.
     """
-    from tanabesugano.mcp._compute import sweep_dq
-
     start = dq_max / steps if dq_min is None else dq_min
-    _dq_values, points = sweep_dq(d_count, start, dq_max, steps, B, C)
-    curve: list[float] = []
+    dq_array, points = sweep_dq(d_count, start, dq_max, steps, B, C)
+    dq_values = [float(dq) for dq in dq_array]
+
+    allowed_raw: list[float] = []
+    any_raw: list[float] = []
+    allowed_branches: list[str | None] = []
+    any_branches: list[str | None] = []
+    any_allowed_flags: list[bool] = []
+    has_allowed = False
     for point in points:
-        all_e = sorted(float(e) for term in point.values() for e in term)
-        curve.append(round(next((e for e in all_e if e > ground_eps), 0.0), 1))
-    return curve
+        _g, allowed_cands = transition_candidates(
+            point,
+            spin_allowed_only=True,
+            min_energy_cm1=_GROUND_FLOOR_CM1,
+        )
+        _g2, any_cands = transition_candidates(
+            point,
+            spin_allowed_only=False,
+            min_energy_cm1=_GROUND_FLOOR_CM1,
+        )
+        any_raw.append(any_cands[0][0] if any_cands else 0.0)
+        any_branches.append(any_cands[0][1] if any_cands else None)
+        # transition_candidates reports allowedness per level; take it from
+        # there rather than assuming. The any-spin curve is spin-allowed for
+        # d3 and d8 the whole way, and only turns forbidden past a crossing
+        # for d2/d4/d6/d7 -- so a blanket "forbidden" badge on this tab
+        # contradicted the "= 10Dq exactly" badge sitting next to it.
+        any_allowed_flags.append(bool(any_cands and any_cands[0][2]))
+        allowed_branches.append(allowed_cands[0][1] if allowed_cands else any_branches[-1])
+        if allowed_cands:
+            has_allowed = True
+            allowed_raw.append(allowed_cands[0][0])
+        else:
+            # High-spin d5 only: no spin-allowed d-d band exists at all, so the
+            # card falls back to the lowest forbidden one and labels it as such.
+            allowed_raw.append(any_raw[-1])
+
+    def _is_ten_dq(values: list[float]) -> bool:
+        # Derived, never tabulated: a hardcoded {3, 4, 6, 8} would be a second
+        # copy of a claim the solver already answers, and would go stale.
+        return all(
+            abs(v - 10.0 * dq) <= _TEN_DQ_TOL_CM1 for v, dq in zip(values, dq_values, strict=True)
+        )
+
+    allowed_label, allowed_ok = _display_transition(d_count, ref_dq, B, C, spin_allowed_only=True)
+    any_label, _ = _display_transition(d_count, dq_values[0], B, C, spin_allowed_only=False)
+
+    allowed_switch_label, allowed_switch_dq = _find_branch_change(
+        d_count, B, C, dq_values, allowed_branches, spin_allowed_only=has_allowed
+    )
+    any_switch_label, any_switch_dq = _find_branch_change(
+        d_count, B, C, dq_values, any_branches, spin_allowed_only=False
+    )
+
+    # Read the reference point off the curve rather than re-solving at ref_dq:
+    # zero extra solves, and the printed number cannot disagree with the plotted
+    # one, which is how the old ref_label drifted from its own sparkline.
+    ref_i = min(range(len(dq_values)), key=lambda i: abs(dq_values[i] - ref_dq))
+
+    return _DashboardBands(
+        dq_values=dq_values,
+        spin_allowed=_BandSeries(
+            values=[round(v, 1) for v in allowed_raw],
+            label=allowed_label,
+            spin_allowed=has_allowed and allowed_ok,
+            is_ten_dq=_is_ten_dq(allowed_raw),
+            ref_energy=round(allowed_raw[ref_i], 1),
+            ref_dq=dq_values[ref_i],
+            switch_label=allowed_switch_label,
+            switch_dq=allowed_switch_dq,
+        ),
+        any_spin=_BandSeries(
+            values=[round(v, 1) for v in any_raw],
+            label=any_label,
+            spin_allowed=all(any_allowed_flags),
+            is_ten_dq=_is_ten_dq(any_raw),
+            ref_energy=round(any_raw[ref_i], 1),
+            ref_dq=dq_values[ref_i],
+            switch_label=any_switch_label,
+            switch_dq=any_switch_dq,
+        ),
+    )
+
+
+def _first_excited_curve(
+    d_count: int,
+    B: float,
+    C: float,
+    *,
+    dq_min: float | None = None,
+    dq_max: float = 1500.0,
+    steps: int = 30,
+) -> list[float]:
+    """Lowest eigenvalue above the ground manifold at each Dq of a sweep.
+
+    The lowest level of *any* multiplicity -- still shipped, as the dashboard's
+    "Lowest level (any spin)" tab. Kept as a named wrapper because its two
+    regression guards (no origin spike, every requested sample returned) are
+    guards on this curve specifically; see :func:`_dashboard_bands` for the
+    sweep itself and for why ``dq_min`` cannot be zero.
+    """
+    return _dashboard_bands(
+        d_count, B, C, dq_min=dq_min, dq_max=dq_max, steps=steps
+    ).any_spin.values
+
+
+def _dashboard_card(
+    d: int,
+    cfg: _DConfig,
+    ions: tuple,
+    note_short: str,
+    series: _BandSeries,
+    dq_values: list[float],
+    *,
+    heading: str,
+) -> None:
+    """Render one dashboard card for one of the two series.
+
+    Both tabs share this so a caption cannot say one thing on one tab and
+    something else on the other; only ``heading`` and the ``series`` differ.
+    """
+    lo, hi = series.values[0], series.values[-1]
+    dq_lo, dq_hi = dq_values[0], dq_values[-1]
+    with pf.Card(css_class="p-4"):
+        pf.Heading(content=f"d{d}", level=4)
+        with pf.Grid(columns=2, gap=2):
+            pf.Metric(label="Ground term", value=cfg["ground_term"])
+            pf.Metric(label="Matrix", value=str(cfg["matrix_size"]), description="terms")
+        pf.Muted(content=f"Ions: {', '.join(ions) if ions else '—'}")
+        pf.Muted(
+            content=f"B = {cfg['default_B']:g} cm⁻¹  C = {cfg['default_C']:g} cm⁻¹",
+        )
+        pf.Text(content=heading, css_class="text-xs text-muted-foreground")
+        Sparkline(data=series.values, height=48, variant="default", fill=True)
+
+        # Endpoints, never min/max: three of these curves descend, and a
+        # min -> max caption printed d5's arrow backwards for exactly that
+        # reason. And the Dq range is read off the sweep, so it cannot go
+        # stale the way the hardcoded "10Dq = 0" did once the sweep start moved.
+        pf.Muted(
+            content=(
+                f"{lo:,.0f} → {hi:,.0f} cm⁻¹ over 10Dq = {10 * dq_lo:,.0f} → {10 * dq_hi:,.0f} cm⁻¹"
+            ),
+            css_class="text-xs",
+        )
+        if series.switch_dq is not None:
+            pf.Muted(
+                content=(
+                    f"{series.label}, then {series.switch_label} above "
+                    f"10Dq ≈ {10 * series.switch_dq:,.0f} cm⁻¹"
+                ),
+                css_class="text-xs",
+            )
+        else:
+            pf.Muted(content=series.label, css_class="text-xs")
+
+        if series.is_ten_dq:
+            pf.Badge(label="= 10Dq exactly", variant="secondary")
+        if not series.spin_allowed:
+            pf.Badge(
+                label=(
+                    "spin-forbidden above the crossing"
+                    if series.switch_dq is not None
+                    else "spin-forbidden"
+                ),
+                variant="warning",
+            )
+
+        pf.Text(
+            content=(
+                f"@ 10Dq = {10 * series.ref_dq:,.0f}: "
+                f"{series.label_at(series.ref_dq)} = {series.ref_energy:,.0f} cm⁻¹"
+            ),
+            css_class="text-xs font-mono text-primary",
+        )
+        if note_short:
+            pf.Muted(content=note_short, css_class="text-xs")
 
 
 def _register_dashboard(mcp: FastMCP) -> None:
@@ -521,10 +879,20 @@ def _register_dashboard(mcp: FastMCP) -> None:
 
         For each d-count card: ground term symbol, matrix size, default Racah
         parameters, representative free ions, a one-line chemical note, and a
-        Sparkline of the **first excited state energy** across a 50–1500 cm⁻¹
-        Dq sweep — the band that an absorption spectrum would actually show.
-        The sweep starts one grid step above zero, not at zero: see
-        :func:`_first_excited_curve` for why Dq = 0 cannot be sampled.
+        Sparkline across a 50–1500 cm⁻¹ Dq sweep.
+
+        Two tabs, because the card used to conflate two different quantities
+        under one unlabelled curve. **Spin-allowed ν₁** is the lowest band an
+        absorption spectrum actually shows; it tracks one transition end to end.
+        **Lowest level (any spin)** is the lowest level of any multiplicity, and
+        its kink marks a spin-forbidden level dropping below the spin-allowed
+        one — real structure, but not what a spectrum shows, and not the
+        high-spin → low-spin ground flip either (the ground term is high-spin
+        across this whole window).
+
+        Both series come from the same sweep, so the second costs no extra
+        solve. The sweep starts one grid step above zero, not at zero: see
+        :func:`_dashboard_bands` for why Dq = 0 cannot be sampled.
         Useful as a 'home page' before drilling into one configuration with
         `ts_diagram_app`.
         """
@@ -532,114 +900,54 @@ def _register_dashboard(mcp: FastMCP) -> None:
         from tanabesugano.mcp._defaults import DEFAULTS
         from tanabesugano.mcp._defaults import GROUND_STATE_NOTES
         from tanabesugano.mcp._defaults import ION_BY_D_COUNT
-        from tanabesugano.plot_style import term_to_unicode
 
-        # Energy threshold above which an eigenvalue counts as a real excited
-        # state — solvers zero the ground manifold so anything ≤ this is noise.
-        ground_eps = 1.0
-        # Representative octahedral Dq for displaying a single absorption-band
-        # number alongside the sparkline. 1000 cm⁻¹ is mid-range for the
-        # transition metals we cover (Dq sits between 600 and 1800 for the
-        # ions listed in ION_BY_D_COUNT).
-        ref_dq = 1000.0
-
-        cards: list[dict] = []
+        cards = []
         for d in SUPPORTED_D_COUNTS:
             cfg = DEFAULTS[d]
-            b = cfg["default_B"]
-            c = cfg["default_C"]
-            # First excited state energy at each Dq step: the lowest eigenvalue
-            # above the ground manifold across all term symbols. This gives a
-            # curve that meaningfully tracks the lowest d-d absorption band as
-            # crystal-field strength grows.
-            spark = _first_excited_curve(d, b, c, ground_eps=ground_eps)
-
-            # At a fixed reference Dq, name the lowest excited term so the
-            # card reports a concrete assignable transition, not just an
-            # energy number floating in space.
-            from tanabesugano.mcp._compute import compute_point
-
-            ref_terms = compute_point(d, ref_dq, b, c)
-            ref_pairs: list[tuple[float, str]] = []
-            for term_name, eigs in ref_terms.items():
-                for e in eigs:
-                    if e > ground_eps:
-                        ref_pairs.append((float(e), term_name))
-            ref_pairs.sort(key=lambda t: t[0])
-            if ref_pairs:
-                first_e, first_term = ref_pairs[0]
-                ref_label = (
-                    f"→ {term_to_unicode(first_term)}: {first_e:,.0f} cm⁻¹"
-                    f"  @ 10Dq = {ref_dq * 10:.0f}"
-                )
-            else:
-                ref_label = ""
-
-            cards.append({"d": d, "cfg": cfg, "spark": spark, "ref_label": ref_label})
+            bands = _dashboard_bands(d, cfg["default_B"], cfg["default_C"])
+            note = GROUND_STATE_NOTES.get(d, "")
+            # Strip the leading "dN (...):" prefix from the note so the
+            # card subtitle doesn't repeat info already shown above.
+            note_short = note.split(":", 1)[-1].strip() if ":" in note else note
+            cards.append((d, cfg, ION_BY_D_COUNT.get(d, ()), note_short, bands))
 
         with PrefabApp() as app, pf.Column(gap=4, css_class="p-6"):
             pf.Heading(content="Tanabe-Sugano: d² – d⁸ overview", level=2)
             pf.Muted(
                 content=(
                     "Per configuration: ground term, matrix size, default Racah "
-                    "B/C, representative free ions, and a sparkline of the first "
-                    "excited state energy from Dq = 50 to 1500 cm⁻¹ — the lowest "
-                    "d-d band an absorption spectrum will show. Use "
-                    "`ts_diagram_app` with d_count = N for the full diagram."
+                    "B/C, representative free ions, and a sparkline over Dq = 50 "
+                    "to 1500 cm⁻¹. Switch tabs to change which band is plotted. "
+                    "Use `ts_diagram_app` with d_count = N for the full diagram."
                 ),
             )
-            with pf.Grid(columns=4, gap=4):
-                for c_data in cards:
-                    d = c_data["d"]
-                    cfg = c_data["cfg"]
-                    ions = ION_BY_D_COUNT.get(d, ())
-                    note = GROUND_STATE_NOTES.get(d, "")
-                    # Strip the leading "dN (...):" prefix from the note so the
-                    # card subtitle doesn't repeat info already shown above.
-                    note_short = note.split(":", 1)[-1].strip() if ":" in note else note
-                    e_min = min(c_data["spark"]) if c_data["spark"] else 0.0
-                    e_max = max(c_data["spark"]) if c_data["spark"] else 0.0
-                    with pf.Card(css_class="p-4"):
-                        pf.Heading(content=f"d{d}", level=4)
-                        with pf.Grid(columns=2, gap=2):
-                            pf.Metric(
-                                label="Ground term",
-                                value=cfg["ground_term"],
-                            )
-                            pf.Metric(
-                                label="Matrix",
-                                value=str(cfg["matrix_size"]),
-                                description="terms",
-                            )
-                        pf.Muted(
-                            content=(f"Ions: {', '.join(ions) if ions else '—'}"),
-                        )
-                        pf.Muted(
-                            content=(
-                                f"B = {cfg['default_B']:g} cm⁻¹  C = {cfg['default_C']:g} cm⁻¹"
+            with pf.Tabs(value="allowed"):
+                with pf.Tab("Spin-allowed ν₁", value="allowed"), pf.Grid(columns=4, gap=4):
+                    for d, cfg, ions, note_short, bands in cards:
+                        _dashboard_card(
+                            d,
+                            cfg,
+                            ions,
+                            note_short,
+                            bands.spin_allowed,
+                            bands.dq_values,
+                            heading=(
+                                "Lowest d-d band (all spin-forbidden):"
+                                if not bands.spin_allowed.spin_allowed
+                                else "First spin-allowed band (cm⁻¹) vs Dq:"
                             ),
                         )
-                        pf.Text(
-                            content="First excited state (cm⁻¹) vs Dq:",
-                            css_class="text-xs text-muted-foreground",
+                with pf.Tab("Lowest level (any spin)", value="any"), pf.Grid(columns=4, gap=4):
+                    for d, cfg, ions, note_short, bands in cards:
+                        _dashboard_card(
+                            d,
+                            cfg,
+                            ions,
+                            note_short,
+                            bands.any_spin,
+                            bands.dq_values,
+                            heading="Lowest level, any multiplicity (cm⁻¹) vs Dq:",
                         )
-                        Sparkline(
-                            data=c_data["spark"],
-                            height=48,
-                            variant="default",
-                            fill=True,
-                        )
-                        pf.Muted(
-                            content=(f"{e_min:.0f} → {e_max:.0f} cm⁻¹ at 10Dq = 0 → 15 000 cm⁻¹"),
-                            css_class="text-xs",
-                        )
-                        if c_data.get("ref_label"):
-                            pf.Text(
-                                content=c_data["ref_label"],
-                                css_class="text-xs font-mono text-primary",
-                            )
-                        if note_short:
-                            pf.Muted(content=note_short, css_class="text-xs")
         return app
 
 

--- a/src/tanabesugano/mcp/apps.py
+++ b/src/tanabesugano/mcp/apps.py
@@ -556,6 +556,13 @@ def _display_transition(
     high-spin d5, whose 6A1g is the configuration's only sextet -- this falls
     back to the lowest level of any multiplicity and returns ``False`` so the
     caller can say so. The fallback is never silent.
+
+    The flag always describes the level that was selected, never the request
+    that was made. An earlier version returned ``not spin_allowed_only`` on the
+    fallback path, so asking for the lowest level of any multiplicity got back
+    ``True`` whatever that level's multiplicity actually was. It was inert --
+    both such callers discard the flag -- but a caller reading it would have
+    been told a forbidden band was allowed.
     """
     manifold = LevelSet.solve(d_count, dq, B, C)
     labels = manifold.display_labels("unicode")
@@ -568,7 +575,11 @@ def _display_transition(
     )
     if excited is None:  # pragma: no cover - every configuration has excited levels
         return labels[manifold.ground.uid], False
-    return f"{labels[manifold.ground.uid]} → {labels[excited.uid]}", not spin_allowed_only
+    return (
+        f"{labels[manifold.ground.uid]} → {labels[excited.uid]}",
+        # Same comparison LevelSet.spin_allowed makes, so the two cannot disagree.
+        excited.multiplicity == manifold.ground.multiplicity,
+    )
 
 
 def _bisect_branch_change(

--- a/src/tanabesugano/test/test_matrices_invariants.py
+++ b/src/tanabesugano/test/test_matrices_invariants.py
@@ -303,10 +303,25 @@ class TestFreeIonRacahClosedForms:
 class TestExactTransitionIdentities:
     """Identities that probe the Racah content, not just the field splitting."""
 
-    @pytest.mark.parametrize(("d_count", "excited"), [(3, "4_T_2"), (8, "3_T_2")])
+    @pytest.mark.parametrize(
+        ("d_count", "excited"),
+        [(3, "4_T_2"), (8, "3_T_2"), (4, "5_T_2"), (6, "5_E")],
+    )
     @pytest.mark.parametrize("b", [400.0, 900.0, 1400.0])
     def test_nu1_is_exactly_10dq(self, d_count: int, excited: str, b: float) -> None:
-        """Independent of B and C: the Racah terms cancel identically."""
+        """Independent of B and C: the Racah terms cancel identically.
+
+        d3/d8 are the classic pair. d4/d6 hold for a different reason and were
+        added when the dashboard began *displaying* the identity: 5D is the only
+        quintet in either configuration, so its Eg/T2g components have nothing to
+        mix with and their separation is exactly Delta_o. Group theory, not a
+        measurement of this solver -- which is what lets it police the
+        "= 10Dq exactly" badge ``ts_dashboard_app`` prints on d3/d4/d6/d8.
+
+        This is the ONLY place nu1 == 10Dq is asserted against the solver. The
+        dashboard tests deliberately do not re-assert it at a second tolerance;
+        they assert their own contract (one transition per curve) instead.
+        """
         dq = 777.0
         states = SOLVERS[d_count](Dq=dq, B=b, C=C_REF).solver().as_dict()
         ground = min(float(e) for v in states.values() for e in np.asarray(v).flatten())

--- a/src/tanabesugano/test/test_mcp.py
+++ b/src/tanabesugano/test/test_mcp.py
@@ -5,6 +5,8 @@ Skips cleanly when the optional `[mcp]` extra (fastmcp) is not installed.
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 
@@ -573,30 +575,119 @@ def test_wrapped_data_args_are_unwrapped() -> None:
     assert flat_len == wrap_len, f"unwrapped output diverged: {flat_len} vs {wrap_len}"
 
 
+def test_dashboard_captions_match_the_curves_they_label() -> None:
+    """Every caption number must be readable off the sparkline beside it.
+
+    The caption is the only thing carrying scale -- a Prefab Sparkline renders
+    "with no axes, labels, or tooltips" and Recharts autoscales each card
+    independently -- so a wrong caption is not cosmetic, it is the whole
+    quantitative content of the card.
+
+    It had been wrong twice over, uncaught, because nothing asserted it:
+    the range was hardcoded ``10Dq = 0 → 15 000`` while the sweep had been moved
+    to start at Dq = 50, and the endpoints were ``min()``/``max()`` rather than
+    first/last, which printed d5's descending curve backwards as
+    ``15842 → 27808``.
+
+    Observed red, by restoring the old caption expression::
+
+        AssertionError: a caption claims the sweep spans 10Dq = 0 → 15,000 cm^-1,
+        but the sparkline beside it was computed over 500 → 15,000
+
+    Deliberately parses the rendered strings rather than re-deriving them: the
+    defect lived in the formatting, so a test that recomputed the same f-string
+    would have agreed with the bug.
+    """
+    result = _call("ts_dashboard_app", {})
+    assert not result.is_error  # type: ignore[attr-defined]
+
+    # Card children arrive in render order, so a Sparkline is followed by its
+    # own caption; pairing them positionally is what ties a number to a curve.
+    flat: list[tuple[str, object]] = []
+
+    def walk(node: object) -> None:
+        if isinstance(node, dict):
+            if node.get("type") in {"Sparkline", "Muted", "Text"}:
+                flat.append((str(node["type"]), node.get("data") or node.get("content")))
+            for child in node.get("children") or []:
+                walk(child)
+
+    walk((result.structured_content or {}).get("view"))  # type: ignore[attr-defined]
+
+    range_re = re.compile(r"([\d,]+) → ([\d,]+) cm⁻¹ over 10Dq = ([\d,]+) → ([\d,]+) cm⁻¹")
+
+    def num(text: str) -> float:
+        return float(text.replace(",", ""))
+
+    checked = 0
+    for i, (kind, payload) in enumerate(flat):
+        if kind != "Sparkline":
+            continue
+        curve = list(payload or [])
+        caption = next(
+            (
+                m
+                for _k, c in flat[i + 1 : i + 4]
+                if isinstance(c, str) and (m := range_re.search(c))
+            ),
+            None,
+        )
+        assert caption is not None, f"sparkline {i} has no range caption beside it"
+        lo, hi, dq_lo, dq_hi = (num(g) for g in caption.groups())
+        checked += 1
+
+        assert (lo, hi) == (round(curve[0]), round(curve[-1])), (
+            f"caption says {lo:,.0f} → {hi:,.0f} cm⁻¹ but the curve runs "
+            f"{curve[0]:,.0f} → {curve[-1]:,.0f} -- min/max instead of endpoints "
+            f"reverses every descending curve."
+        )
+        assert (dq_lo, dq_hi) == (500.0, 15000.0), (
+            f"a caption claims the sweep spans 10Dq = {dq_lo:,.0f} → {dq_hi:,.0f} "
+            f"cm⁻¹, but the sparkline beside it was computed over 500 → 15,000"
+        )
+
+    assert checked == 14, f"expected to check 14 captions, checked {checked}"
+
+
 def test_dashboard_sparklines_show_meaningful_data() -> None:
     """Pins the dashboard fix: each d-card's Sparkline must vary (not flat zero)
-    because it now plots the first excited state energy across the Dq sweep,
-    not the ground-term energy (which is always 0 by construction).
+    because it plots a real band energy across the Dq sweep, not the ground-term
+    energy (which is always 0 by construction).
+
+    Fourteen, not seven: the card carries two tabs -- "Spin-allowed nu1" and
+    "Lowest level (any spin)" -- and both panels ship in the same payload, since
+    Prefab switches tabs client-side. Both are asserted, because the tab a
+    reader never opens is exactly where a regression would sit unnoticed.
     """
     result = _call("ts_dashboard_app", {})
     assert not result.is_error  # type: ignore[attr-defined]
 
     sparks: list[list[float]] = []
+    tabs: list[str] = []
 
     def walk(node: object) -> None:
         if isinstance(node, dict):
             if node.get("type") == "Sparkline":
                 sparks.append(node.get("data") or [])
+            elif node.get("type") == "Tab":
+                tabs.append(str(node.get("title") or node.get("value") or ""))
             for child in node.get("children") or []:
                 walk(child)
 
     view = (result.structured_content or {}).get("view")  # type: ignore[attr-defined]
     walk(view)
 
-    assert len(sparks) == 7, f"expected one sparkline per d-config, got {len(sparks)}"
-    for d, spark in zip(range(2, 9), sparks, strict=True):
-        assert spark, f"d{d} sparkline is empty"
-        assert max(spark) > 100, f"d{d} sparkline never rises above 100 cm⁻¹ — still flat zero?"
+    assert len(tabs) == 2, f"expected two tabs, got {len(tabs)}: {tabs}"
+    assert len(sparks) == 14, (
+        f"expected one sparkline per d-config per tab (7 x 2), got {len(sparks)}"
+    )
+    for i, spark in enumerate(sparks):
+        d = 2 + i % 7
+        tab = tabs[i // 7]
+        assert spark, f"d{d} sparkline on the {tab!r} tab is empty"
+        assert max(spark) > 100, (
+            f"d{d} on the {tab!r} tab never rises above 100 cm⁻¹ — still flat zero?"
+        )
 
 
 def test_oxidation_landscape_scatter_does_not_connect_d_counts() -> None:

--- a/src/tanabesugano/test/test_mcp_regressions.py
+++ b/src/tanabesugano/test/test_mcp_regressions.py
@@ -479,6 +479,44 @@ class TestDashboardSparkline:
             )
 
     @pytest.mark.parametrize("d_count", D_COUNTS)
+    @pytest.mark.parametrize("dq", [500.0, 1500.0])
+    def test_display_transition_reports_real_allowedness(self, d_count: int, dq: float) -> None:
+        """The allowedness flag must describe the level, not the caller's request.
+
+        ``_display_transition`` returned ``not spin_allowed_only`` on its
+        fallback path -- so asking it for the lowest level of any multiplicity
+        got back "spin-allowed: True" unconditionally, whatever the level's
+        multiplicity actually was. Inert when caught, because both
+        ``spin_allowed_only=False`` callers discarded the flag, but wrong the
+        moment anyone reads it.
+
+        Cross-checked against ``transition_candidates``, which answers the same
+        question by a genuinely different route -- ``LevelSet.from_states`` plus
+        ``term_multiplicity`` on the solver keys, versus ``LevelSet.solve`` plus
+        ``Level.multiplicity`` here. Two paths, one answer; re-deriving it the
+        same way would only have restated the bug.
+
+        Observed red at Dq = 1500 on the configurations whose lowest level has
+        crossed to a forbidden branch, and at both Dq for d5::
+
+            AssertionError: d4 at Dq=1500: _display_transition reports
+            spin_allowed=True for 5Eg → 3T1g(H,a), but transition_candidates
+            says False.
+        """
+        B, C = defaults_for(d_count)
+        label, allowed = ts_apps._display_transition(d_count, dq, B, C, spin_allowed_only=False)
+        _ground, candidates = ts_compute.transition_candidates(
+            compute_point(d_count, dq, B, C), spin_allowed_only=False
+        )
+        expected = candidates[0][2]
+
+        assert allowed == expected, (
+            f"d{d_count} at Dq={dq:.0f}: _display_transition reports "
+            f"spin_allowed={allowed} for {label}, but transition_candidates "
+            f"says {expected}."
+        )
+
+    @pytest.mark.parametrize("d_count", D_COUNTS)
     def test_the_two_badges_can_never_contradict_each_other(self, d_count: int) -> None:
         """No series may be both "= 10Dq exactly" and "spin-forbidden".
 

--- a/src/tanabesugano/test/test_mcp_regressions.py
+++ b/src/tanabesugano/test/test_mcp_regressions.py
@@ -368,6 +368,194 @@ class TestDashboardSparkline:
             f"sweep start above Dq=0."
         )
 
+    @pytest.mark.parametrize("d_count", D_COUNTS)
+    def test_spin_allowed_curve_tracks_one_transition(self, d_count: int) -> None:
+        """The nu1 sparkline must never change which band it plots.
+
+        This is the kink guard, and the only correct spelling of it. Asserting
+        monotonicity would be false physics -- high-spin d5 descends by ~500
+        cm^-1 per step, as the sibling test above already records. What makes a
+        kink a defect is not its slope but that the curve swaps transitions
+        underneath an unlabelled sparkline, so the caption can only ever name
+        one of the two branches.
+
+        Observed red, produced by pointing this same assertion at the
+        ``any_spin`` series -- which kinks by design and is what the card used
+        to plot. Exactly d2/d4/d6/d7 fired, d3/d5/d8 passed::
+
+            AssertionError: d4: the plotted band changes identity mid-sweep --
+            5Eg -> 5T2g up to 10Dq = 12,766 cm^-1, then 5Eg -> 3T1g(H,a). A
+            sparkline that swaps transitions has a kink that is not physics,
+            and its caption can only name one of the two.
+        """
+        B, C = defaults_for(d_count)
+        series = ts_apps._dashboard_bands(d_count, B, C).spin_allowed
+
+        assert series.switch_dq is None, (
+            f"d{d_count}: the plotted band changes identity mid-sweep -- "
+            f"{series.label} up to 10Dq = {10 * (series.switch_dq or 0):,.0f} cm^-1, "
+            f"then {series.switch_label}. A sparkline that swaps transitions has a "
+            f"kink that is not physics, and its caption can only name one of the two."
+        )
+
+    # The four configurations whose lowest level of ANY multiplicity changes
+    # branch inside the 50-1500 cm^-1 window, and the approximate 10Dq at which
+    # it does. Group theory decides membership, not this solver: a low-spin
+    # excited level descends fast enough to dive under the high-spin one only
+    # where a low-spin manifold exists nearby. d3/d5/d8 have none, so they never
+    # cross. Values are brackets, deliberately loose -- this test pins WHICH
+    # configurations cross, not where.
+    ANY_SPIN_CROSSINGS = {2: 14_730, 4: 12_766, 6: 13_992, 7: 11_047}
+
+    @pytest.mark.parametrize("d_count", D_COUNTS)
+    def test_branch_detector_still_fires_on_the_curve_that_kinks(self, d_count: int) -> None:
+        """The any-spin series must still report its crossing.
+
+        The companion to ``test_spin_allowed_curve_tracks_one_transition``, and
+        the reason that one is not a tautology. "No branch change" is only
+        evidence of a working filter if the detector is known to fire when there
+        IS one -- otherwise hardcoding ``switch_dq = None`` would satisfy the
+        guard, which is exactly the bug a mutation check caught in the first
+        draft of these tests.
+
+        It also pins the physics the "Lowest level (any spin)" tab exists to
+        show: a spin-forbidden level dropping below the spin-allowed band. Note
+        this is NOT the HS -> LS ground flip -- the ground term is high-spin
+        across this whole window, and the real crossovers sit at 10Dq = 26 386
+        (d4), 21 348 (d6) and 21 058 (d7), roughly twice as far out.
+        """
+        B, C = defaults_for(d_count)
+        series = ts_apps._dashboard_bands(d_count, B, C).any_spin
+        expected = self.ANY_SPIN_CROSSINGS.get(d_count)
+
+        if expected is None:
+            assert series.switch_dq is None, (
+                f"d{d_count}: reported a branch change at 10Dq = "
+                f"{10 * (series.switch_dq or 0):,.0f} cm^-1, but it has no low-spin "
+                f"manifold near enough to cross inside this window."
+            )
+            return
+
+        assert series.switch_dq is not None, (
+            f"d{d_count}: expected a branch change near 10Dq = {expected:,} cm^-1 "
+            f"and found none -- the detector has stopped firing, which would make "
+            f"the spin-allowed guard vacuous."
+        )
+        assert 10 * series.switch_dq == pytest.approx(expected, rel=0.05), (
+            f"d{d_count}: branch change at 10Dq = {10 * series.switch_dq:,.0f} cm^-1, "
+            f"expected near {expected:,}."
+        )
+
+    @pytest.mark.parametrize("d_count", D_COUNTS)
+    def test_only_d5_falls_back_to_a_forbidden_band(self, d_count: int) -> None:
+        """The spin-forbidden fallback is d5's alone, and is never silent.
+
+        High-spin d5 has exactly one sextet, so it has zero spin-allowed d-d
+        transitions and the nu1 tab has nothing to plot; it falls back to the
+        lowest forbidden band and says so. Every other configuration has at
+        least one spin-allowed band (d4 and d6 have exactly one), so a ``False``
+        anywhere else means the filter has silently stopped working -- the same
+        failure mode ``term_multiplicity`` was hardened against, where a
+        multiplicity comparison that was never true disabled spin-allowed
+        filtering in four tools with no error.
+
+        Provenance: the count is group theory, not a measurement -- d5's free-ion
+        terms hold a single 6S. Observed red by inverting the expectation::
+
+            AssertionError: d5: expected a spin-allowed band, found none
+        """
+        B, C = defaults_for(d_count)
+        series = ts_apps._dashboard_bands(d_count, B, C).spin_allowed
+
+        if d_count == 5:
+            assert not series.spin_allowed, (
+                "d5: reported a spin-allowed band, but 6A1g is the only sextet in "
+                "the configuration so every d-d transition is spin-forbidden."
+            )
+        else:
+            assert series.spin_allowed, (
+                f"d{d_count}: expected a spin-allowed band, found none -- the "
+                f"multiplicity filter has stopped matching the ground term."
+            )
+
+    @pytest.mark.parametrize("d_count", D_COUNTS)
+    def test_the_two_badges_can_never_contradict_each_other(self, d_count: int) -> None:
+        """No series may be both "= 10Dq exactly" and "spin-forbidden".
+
+        nu1 == 10Dq holds precisely because the band is a single t2g -> eg
+        promotion within one free-ion term, which is spin-allowed by
+        construction. A series carrying both badges is therefore not a cosmetic
+        clash but a claim that cannot be true.
+
+        Observed red on the rendered card, not in a test -- which is why this
+        exists. The first draft hardcoded ``spin_allowed=False`` on the any-spin
+        series, so every card on that tab wore an amber "spin-forbidden" badge,
+        including d3 and d8 whose lowest level of any multiplicity is the
+        spin-allowed 4A2g -> 4T2g / 3A2g -> 3T2g the whole way. d3 rendered
+        "= 10Dq exactly" and "spin-forbidden" side by side::
+
+            AssertionError: d3 any_spin: badged "= 10Dq exactly" and
+            "spin-forbidden" at once, but nu1 == 10Dq is a spin-allowed
+            single-electron promotion by construction.
+        """
+        B, C = defaults_for(d_count)
+        bands = ts_apps._dashboard_bands(d_count, B, C)
+
+        for name in ("spin_allowed", "any_spin"):
+            series = getattr(bands, name)
+            assert not (series.is_ten_dq and not series.spin_allowed), (
+                f'd{d_count} {name}: badged "= 10Dq exactly" and "spin-forbidden" '
+                f"at once, but nu1 == 10Dq is a spin-allowed single-electron "
+                f"promotion by construction."
+            )
+
+    @pytest.mark.parametrize("d_count", D_COUNTS)
+    def test_any_spin_allowedness_is_read_off_the_levels(self, d_count: int) -> None:
+        """Only d3 and d8 keep a spin-allowed band as their lowest level throughout.
+
+        Everywhere else the any-spin curve either starts forbidden (d5) or turns
+        forbidden past its crossing (d2/d4/d6/d7), which is the entire reason
+        that tab is worth showing separately. Membership is group theory: d3 and
+        d8 have no low-spin manifold near enough to dive under nu1 inside this
+        window.
+        """
+        B, C = defaults_for(d_count)
+        series = ts_apps._dashboard_bands(d_count, B, C).any_spin
+
+        assert series.spin_allowed == (d_count in {3, 8}), (
+            f"d{d_count}: any-spin curve reports spin_allowed="
+            f"{series.spin_allowed}; only d3 and d8 stay spin-allowed for the "
+            f"whole sweep."
+        )
+
+    @pytest.mark.parametrize("d_count", D_COUNTS)
+    def test_ten_dq_badge_is_derived_not_asserted(self, d_count: int) -> None:
+        """The '= 10Dq exactly' badge must agree with the curve it labels.
+
+        Deliberately NOT a restatement of nu1 == 10Dq -- that claim is asserted
+        once, against the solver, in
+        ``test_matrices_invariants.TestExactTransitionIdentities``. Asserting it
+        here too would be the same fixture at two tolerances, and the looser one
+        would mask the tighter. What this pins is narrower and is the dashboard's
+        own contract: whatever the badge says, the plotted values back it up.
+
+        So the expectation is read off the curve, not off a ``{3, 4, 6, 8}``
+        table -- a hardcoded set would be a second copy of a claim the solver
+        already answers, and would go stale the first time a default B changed.
+        """
+        B, C = defaults_for(d_count)
+        bands = ts_apps._dashboard_bands(d_count, B, C)
+        series = bands.spin_allowed
+
+        exact = all(
+            abs(v - 10.0 * dq) <= 0.05  # the values are rounded to 0.1 cm^-1
+            for v, dq in zip(series.values, bands.dq_values, strict=True)
+        )
+        assert series.is_ten_dq == exact, (
+            f"d{d_count}: badge says is_ten_dq={series.is_ten_dq} but the curve "
+            f"{'does' if exact else 'does not'} satisfy nu1 == 10Dq at every point."
+        )
+
 
 class TestHeatmapEnergyAxis:
     """The density heatmap's energy axis, which once rendered inverted.

--- a/uv.lock
+++ b/uv.lock
@@ -2412,7 +2412,7 @@ wheels = [
 
 [[package]]
 name = "tanabesugano"
-version = "2.0.0b1"
+version = "2.0.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
## What

`ts_dashboard_app`'s sparkline plots the band the card actually claims, and the card now offers both candidate series behind a tab pair. Ships as **2.0.0-beta.2**.

## Why

Four of the seven cards (d2, d4, d6, d7) had a visible kink. It was not a rendering artifact: `_first_excited_curve` flattened **all** eigenvalues of **all** terms and took the lowest above a 1 cm⁻¹ floor, with no multiplicity filter. So the plotted series silently changed which transition it tracked mid-sweep — d4 ran ⁵Eg→⁵T₂g until 10Dq ≈ 12 766 cm⁻¹, then switched to ⁵Eg→³T₁g. That switch *is* the kink.

The card's text promised "the lowest d-d band an absorption spectrum will show", so past the kink it plotted a spin-forbidden line ~20× too weak to be the band it named. **The defect was the mismatch, not the kink.**

Both quantities are legitimate, and both are read off the *same* sweep points — so the second costs no extra solve:

| tab | quantity | shape |
|---|---|---|
| **Spin-allowed ν₁** (default) | what a spectrum shows | one transition end to end, no kink |
| **Lowest level (any spin)** | lowest level of any multiplicity | keeps the crossing, names both branches and the 10Dq where they swap |

Prefab switches tabs client-side, so both panels ship in one payload with no MCP round-trip.

## Also fixed (all previously untested)

- **Captions misreported their own axes.** Hardcoded `10Dq = 0` against a sweep that starts at Dq = 50, and `min()`/`max()` instead of endpoints — which printed d5's descending curve backwards as `15842 → 27808`.
- **d5 fallback is now explicit.** High-spin d⁵ has no spin-allowed d-d band at all (⁶A₁g is its only sextet), so it falls back to the lowest forbidden one behind a badge. Never silent.
- **Labels use free-ion parentage** (`³T₁g(F)`, `⁴T₁g(G)`) via `LevelSet.solve` rather than `from_states`, which skips parentage derivation and falls back to the positional `(a)`/`(b)` that appears in no textbook.
- **Selection routes through the shared `transition_candidates`.** The dashboard was the one surface bypassing it, declaring `ground_eps` locally twice — exactly what the note above `_compute.py`'s shared helpers forbids.

## Reviewer notes

**The kink is not the spin crossover.** The ground term is high-spin across the whole 50–1500 cm⁻¹ window for every configuration. The excited-level crossings sit at roughly half the ground-term crossover:

| | kink | true HS→LS ground flip |
|---|---|---|
| d4 | 10Dq ≈ 12 766 | 26 386 |
| d6 | 10Dq ≈ 13 992 | 21 348 |
| d7 | 10Dq ≈ 11 047 | 21 058 |

**Four cards become the identical straight line 500 → 15 000**, because ν₁ = 10Dq exactly for d3/d4/d6/d8. That is the physics, and it is why those configurations let you read Dq straight off a spectrum — surfaced as a derived `= 10Dq exactly` badge rather than a hardcoded `{3, 4, 6, 8}` set that would go stale.

**Test placement.** `nu1 == 10Dq` is extended to d4 (`5_T_2`) and d6 (`5_E`) in `test_matrices_invariants.py`, the module that already owns that claim — ⁵D is the only quintet in either configuration, so its Eg/T₂g components have nothing to mix with and the gap is exactly Δₒ, independent of B (verified to 1e-8 at B = 400/900/1400). The dashboard tests deliberately do **not** restate it at a second tolerance; they assert their own contract instead.

**Two bugs found during the work, both worth knowing about:**

1. A mutation check caught the kink guard asserting a **hardcoded `None`** — a mutation that disabled the spin filter entirely passed it. The observed red had come from the sibling `any_spin` series, a different code path. Fixed by deriving the branch change for both series, plus a companion test proving the detector fires on the curve that does kink; "no branch change" is only evidence of a working filter if the detector is known to fire when there is one.
2. The **rendered card**, not any test, showed every any-spin card badged `spin-forbidden` — including d3 and d8, whose lowest level is spin-allowed throughout. d3 displayed `= 10Dq exactly` and `spin-forbidden` side by side. Now pinned: ν₁ = 10Dq holds *because* the band is a spin-allowed single-electron promotion, so no series can carry both badges.

## Verification

- `uv run poe check` — lint, format, types, full suite, artifact drift: green
- `uv run poe test-mcp` — 53 passed
- Dashboard regression tests — 56 passed
- Screenshot render inspected on **both** tabs

Reviewers pulling this will need to restart the `tanabesugano` MCP server against this branch to exercise the tool live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct dashboard band selection and presentation while exposing both spin-allowed and any-spin series in the 2.0.0-beta.2 release.

New Features:
- Add dashboard tabs for spin-allowed ν₁ bands and lowest levels of any spin, including branch-change information and relevant badges.

Bug Fixes:
- Ensure dashboard sparklines consistently track the claimed transition instead of silently switching branches.
- Correct dashboard captions to reflect sweep endpoints and actual Dq ranges.
- Make d5's lack of spin-allowed d-d transitions explicit through a visible fallback indication.
- Use free-ion parentage in dashboard transition labels and report level allowedness accurately.

Enhancements:
- Route dashboard transition selection through the shared transition-candidate helpers.
- Derive the exact 10Dq identity badge from plotted curve data.

Build:
- Release version 2.0.0-beta.2 and update package metadata and lockfile.

Documentation:
- Document the dashboard's two band interpretations and clarify that excited-level crossings are distinct from ground-state spin crossover.

Tests:
- Extend exact-transition invariant coverage to d4 and d6.
- Add dashboard regression coverage for captions, transition identity, branch detection, fallback behavior, allowedness, badges, and both tab series.

Chores:
- Update the changelog for the beta.2 release.