### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-08-23
+
+General availability release. No functional changes since
+`2.0.0-beta.2` — see the `alpha.1` through `beta.2` entries below for
+everything that shipped on the way to 2.0.
+
 ## [2.0.0-beta.2] - 2026-08-23
 ### Fixed
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
 - family-names: "thebadgerchemist"
 - family-names: "Imgbot"
 title: "TanabeSugano"
-version: 2.0.0-beta.2
+version: 2.0.0
 doi: 10.5281/zenodo.7751230
 date-released: 2026-08-23
 url: "https://github.com/Anselmoo/TanabeSugano"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tanabesugano"
-version = "2.0.0-beta.2"
+version = "2.0.0"
 description = "A python-solver for Tanabe-Sugano and Energy-Correlation diagrams"
 authors = [{ name = "Anselm Hahn", email = "anselm.hahn@gmail.com" }]
 maintainers = [{ name = "Anselm Hahn", email = "anselm.hahn@gmail.com" }]

--- a/src/tanabesugano/__init__.py
+++ b/src/tanabesugano/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import annotations
 
 
-__version__ = "2.0.0-beta.2"
+__version__ = "2.0.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2412,7 +2412,7 @@ wheels = [
 
 [[package]]
 name = "tanabesugano"
-version = "2.0.0b2"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary
- Finalizes the `2.0.0` pre-release chain (`alpha.1` → `alpha.2` → `beta.1` → `beta.2`) into the official `2.0.0` GA release.
- No functional changes since `2.0.0-beta.2` — `HEAD` and the `v2.0.0-beta.2` tag are the same commit, so this is a version-only cut.
- Bumped via `rrt bump 2.0.0` (explicit version, not `rrt bump major`; see note below) across the 3 configured version targets (`pyproject.toml`, `src/tanabesugano/__init__.py`, `CITATION.cff`) plus `uv.lock`.
- `CHANGELOG.md` carries a short `[2.0.0]` GA note; the real changes stay recorded under the `alpha.1`–`beta.2` headings below it.

## Note on `rrt bump major`
`rrt bump major` on this tree would produce `3.0.0`, not `2.0.0` — it unconditionally computes `major + 1` regardless of pre-release state, so a `2.0.0-beta.2` tree has no `rrt bump` invocation that finalizes to `2.0.0`. Used the explicit-version form (`rrt bump 2.0.0`) to sidestep it. Filing this as an issue against `repo-release-tools` separately.

## Test plan
- [x] `uv run poe check` (lint, format, types, tests, artifact-drift) — all green
- [x] Confirmed no `2.0.0-beta` string remains in any version target
- [ ] Merge, then tag `v2.0.0` and push (triggers PyPI publish + GitHub Release) — holding for explicit go-ahead post-merge

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01YaVkr2sMriQveMTouF524h

## Summary by Sourcery

Finalize the 2.0.0 general availability release without functional changes.

Build:
- Update the project and lockfile metadata to version 2.0.0.

Documentation:
- Add the 2.0.0 general availability release note to the changelog.